### PR TITLE
Cleanup

### DIFF
--- a/Threadily.SampleObjects/Threadily.SampleObjects.vcxproj
+++ b/Threadily.SampleObjects/Threadily.SampleObjects.vcxproj
@@ -80,26 +80,42 @@
     </ClCompile>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cd
-copy /Y *.h $(OutputPath).
-IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 EmptyThreadObject.cpp PrimativesThreadObject.cpp ThreadablesThreadObject.cpp -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz
+xcopy /s/Y *.h $(OutputPath).
+set LIST=
+SETLOCAL EnableDelayedExpansion 
+for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
+IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz
+ENDLOCAL
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cd
-copy /Y *.h $(OutputPath).
-IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 EmptyThreadObject.cpp PrimativesThreadObject.cpp ThreadablesThreadObject.cpp -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz
+xcopy /s/Y *.h $(OutputPath).
+set LIST=
+SETLOCAL EnableDelayedExpansion 
+for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
+IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz
+ENDLOCAL
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cd
-copy /Y *.h $(OutputPath).
-IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 EmptyThreadObject.cpp PrimativesThreadObject.cpp ThreadablesThreadObject.cpp -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz
+xcopy /s/Y *.h $(OutputPath).
+set LIST=
+SETLOCAL EnableDelayedExpansion 
+for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
+IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz
+ENDLOCAL
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cd
-copy /Y *.h $(OutputPath).
-IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 EmptyThreadObject.cpp PrimativesThreadObject.cpp ThreadablesThreadObject.cpp -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz
+xcopy /s/Y *.h $(OutputPath).
+set LIST=
+SETLOCAL EnableDelayedExpansion 
+for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
+IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz
+ENDLOCAL
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/Threadily/Observable.h
+++ b/Threadily/Observable.h
@@ -15,7 +15,7 @@
 /// Template for how to create callback handlers for Observable types. Use before the EMSCRIPTEN_BINDINGS line.
 
 #define defineCallbackHandler(typeName, externalNameExtension) \
-	class ISubscribeHandle##externalNameExtension##CallbackWrapper : public wrapper<ISubscribeHandleCallback<typeName>> \
+	class ISubscribeHandle##externalNameExtension##CallbackWrapper : public wrapper<threadily::ISubscribeHandleCallback<typeName>> \
 	{ \
 	public: \
 		EMSCRIPTEN_WRAPPER(ISubscribeHandle##externalNameExtension##CallbackWrapper); \
@@ -25,7 +25,7 @@
 	}; \
 
 #define defineThreadObjectCallbackHandler(typeName, externalNameExtension) \
-	class ISubscribeHandle##externalNameExtension##CallbackWrapper : public wrapper<ISubscribeHandleCallback<typeName>> \
+	class ISubscribeHandle##externalNameExtension##CallbackWrapper : public wrapper<threadily::ISubscribeHandleCallback<typeName>> \
 	{ \
 	public: \
 		EMSCRIPTEN_WRAPPER(ISubscribeHandle##externalNameExtension##CallbackWrapper); \
@@ -36,22 +36,22 @@
 
 /// Template for how to create callback handlers for Observable Vector types. Use before the EMSCRIPTEN_BINDINGS line.
 #define defineCallbackVectorHandler(typeName, externalNameExtension) \
-	class ISubscribeHandle##externalNameExtension##VectorCallbackWrapper : public wrapper<ISubscribeHandleVectorCallback<typeName>> \
+	class ISubscribeHandle##externalNameExtension##VectorCallbackWrapper : public wrapper<threadily::ISubscribeHandleVectorCallback<typeName>> \
 	{ \
 	public: \
 		EMSCRIPTEN_WRAPPER(ISubscribeHandle##externalNameExtension##VectorCallbackWrapper); \
-		void onChange(typeName work, size_t index, ObservableActionType action) { \
+		void onChange(typeName work, size_t index, threadily::ObservableActionType action) { \
 			return call<void>("onChange", work, index, action); \
 		} \
 	}; \
 
 /// Template for how to create callback handlers for Observable Vector types. Use before the EMSCRIPTEN_BINDINGS line.
 #define defineThreadObjectCallbackVectorHandler(typeName, externalNameExtension) \
-	class ISubscribeHandle##externalNameExtension##VectorCallbackWrapper : public wrapper<ISubscribeHandleVectorCallback<typeName>> \
+	class ISubscribeHandle##externalNameExtension##VectorCallbackWrapper : public wrapper<threadily::ISubscribeHandleVectorCallback<typeName>> \
 	{ \
 	public: \
 		EMSCRIPTEN_WRAPPER(ISubscribeHandle##externalNameExtension##VectorCallbackWrapper); \
-		void onChange(std::shared_ptr<typeName> work, size_t index, ObservableActionType action) { \
+		void onChange(std::shared_ptr<typeName> work, size_t index, threadily::ObservableActionType action) { \
 			return call<void>("onChange", work, index, action); \
 		} \
 	}; \
@@ -60,64 +60,64 @@
 #define EXPAND_AND_QUOTE(str) QUOTE(str)
 /// Template for how to create Observable types. Use inside the EMSCRIPTEN_BINDINGS line.
 #define defineObservable(typeName, externalNameExtension) \
-	class_<Observable<typeName>>(EXPAND_AND_QUOTE(Observable##externalNameExtension)) \
-		.smart_ptr<std::shared_ptr<Observable<typeName>>>(EXPAND_AND_QUOTE(Observable##externalNameExtension)) \
-		.function("get", &Observable<typeName>::get) \
-		.function("set", &Observable<typeName>::set) \
-		.function("subscribe", select_overload<std::shared_ptr<ISubscribeHandle>(ISubscribeHandleCallback<typeName>*)>(&Observable<typeName>::subscribe), allow_raw_pointers()) \
+	class_<threadily::Observable<typeName>>(EXPAND_AND_QUOTE(Observable##externalNameExtension)) \
+		.smart_ptr<std::shared_ptr<threadily::Observable<typeName>>>(EXPAND_AND_QUOTE(Observable##externalNameExtension)) \
+		.function("get", &threadily::Observable<typeName>::get) \
+		.function("set", &threadily::Observable<typeName>::set) \
+		.function("subscribe", select_overload<std::shared_ptr<threadily::ISubscribeHandle>(threadily::ISubscribeHandleCallback<typeName>*)>(&threadily::Observable<typeName>::subscribe), allow_raw_pointers()) \
 		; \
-	class_<ISubscribeHandleCallback<typeName>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##Callback)) \
-		.smart_ptr<std::shared_ptr<ISubscribeHandleCallback<typeName>>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##Callback)) \
-		.function("onChange", &ISubscribeHandleCallback<typeName>::onChange, pure_virtual()) \
+	class_<threadily::ISubscribeHandleCallback<typeName>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##Callback)) \
+		.smart_ptr<std::shared_ptr<threadily::ISubscribeHandleCallback<typeName>>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##Callback)) \
+		.function("onChange", &threadily::ISubscribeHandleCallback<typeName>::onChange, pure_virtual()) \
 		.allow_subclass<ISubscribeHandle##externalNameExtension##CallbackWrapper>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##CallbackWrapper)) \
 		; \
 
 /// Template for how to create Observable vector types. Use inside the EMSCRIPTEN_BINDINGS line.
 #define defineObservableVector(typeName, externalNameExtension) \
-	class_<Observable<std::vector<typeName>>>(EXPAND_AND_QUOTE(ObservableVector##externalNameExtension)) \
-		.smart_ptr<std::shared_ptr<Observable<std::vector<typeName>>>>(EXPAND_AND_QUOTE(ObservableVector##externalNameExtension)) \
-		.function("size", &Observable<std::vector<typeName>>::size) \
-		.function("at", &Observable<std::vector<typeName>>::at) \
-		.function("insert", &Observable<std::vector<typeName>>::insert) \
-		.function("set", &Observable<std::vector<typeName>>::set) \
-		.function("erase", &Observable<std::vector<typeName>>::erase) \
-		.function("subscribe", select_overload<std::shared_ptr<ISubscribeHandle>(ISubscribeHandleVectorCallback<typeName>*)>(&Observable<std::vector<typeName>>::subscribe), allow_raw_pointers()) \
+	class_<threadily::Observable<std::vector<typeName>>>(EXPAND_AND_QUOTE(ObservableVector##externalNameExtension)) \
+		.smart_ptr<std::shared_ptr<threadily::Observable<std::vector<typeName>>>>(EXPAND_AND_QUOTE(ObservableVector##externalNameExtension)) \
+		.function("size", &threadily::Observable<std::vector<typeName>>::size) \
+		.function("at", &threadily::Observable<std::vector<typeName>>::at) \
+		.function("insert", &threadily::Observable<std::vector<typeName>>::insert) \
+		.function("set", &threadily::Observable<std::vector<typeName>>::set) \
+		.function("erase", &threadily::Observable<std::vector<typeName>>::erase) \
+		.function("subscribe", select_overload<std::shared_ptr<threadily::ISubscribeHandle>(threadily::ISubscribeHandleVectorCallback<typeName>*)>(&threadily::Observable<std::vector<typeName>>::subscribe), allow_raw_pointers()) \
 		; \
-	class_<ISubscribeHandleVectorCallback<typeName>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##VectorCallback)) \
-		.smart_ptr<std::shared_ptr<ISubscribeHandleVectorCallback<typeName>>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##VectorCallback)) \
-		.function("onChange", &ISubscribeHandleVectorCallback<typeName>::onChange, pure_virtual()) \
+	class_<threadily::ISubscribeHandleVectorCallback<typeName>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##VectorCallback)) \
+		.smart_ptr<std::shared_ptr<threadily::ISubscribeHandleVectorCallback<typeName>>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##VectorCallback)) \
+		.function("onChange", &threadily::ISubscribeHandleVectorCallback<typeName>::onChange, pure_virtual()) \
 		.allow_subclass<ISubscribeHandle##externalNameExtension##VectorCallbackWrapper>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##VectorCallbackWrapper)) \
 		; \
 
 /// Template for how to create Observable types. Use inside the EMSCRIPTEN_BINDINGS line.
 #define defineThreadObjectObservable(typeName, externalNameExtension) \
-	class_<Observable<typeName>>(EXPAND_AND_QUOTE(Observable##externalNameExtension)) \
-		.smart_ptr<std::shared_ptr<Observable<typeName>>>(EXPAND_AND_QUOTE(Observable##externalNameExtension)) \
-		.function("get", &Observable<typeName>::get) \
-		.function("set", &Observable<typeName>::set) \
-		.function("subscribe", select_overload<std::shared_ptr<ISubscribeHandle>(ISubscribeHandleCallback<typeName>*)>(&Observable<typeName>::subscribe), allow_raw_pointers()) \
+	class_<threadily::Observable<typeName>>(EXPAND_AND_QUOTE(Observable##externalNameExtension)) \
+		.smart_ptr<std::shared_ptr<threadily::Observable<typeName>>>(EXPAND_AND_QUOTE(Observable##externalNameExtension)) \
+		.function("get", &threadily::Observable<typeName>::get) \
+		.function("set", &threadily::Observable<typeName>::set) \
+		.function("subscribe", select_overload<std::shared_ptr<threadily::ISubscribeHandle>(threadily::ISubscribeHandleCallback<typeName>*)>(&threadily::Observable<typeName>::subscribe), allow_raw_pointers()) \
 		; \
-	class_<ISubscribeHandleCallback<typeName>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##Callback)) \
-		.smart_ptr<std::shared_ptr<ISubscribeHandleCallback<typeName>>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##Callback)) \
-		.function("onChange", &ISubscribeHandleCallback<typeName>::onChange, pure_virtual()) \
+	class_<threadily::ISubscribeHandleCallback<typeName>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##Callback)) \
+		.smart_ptr<std::shared_ptr<threadily::ISubscribeHandleCallback<typeName>>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##Callback)) \
+		.function("onChange", &threadily::ISubscribeHandleCallback<typeName>::onChange, pure_virtual()) \
 		.allow_subclass<ISubscribeHandle##externalNameExtension##CallbackWrapper>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##CallbackWrapper)) \
 		; \
 
 // std::shared_ptr<Observable<std::vector<EmptyThreadObject>>>
 /// Template for how to create Observable vector types. Use inside the EMSCRIPTEN_BINDINGS line.
 #define defineThreadObjectObservableVector(typeName, externalNameExtension) \
-	class_<Observable<std::vector<typeName>>>(EXPAND_AND_QUOTE(ObservableVector##externalNameExtension)) \
-		.smart_ptr<std::shared_ptr<Observable<std::vector<typeName>>>>(EXPAND_AND_QUOTE(ObservableVector##externalNameExtension)) \
-		.function("size", &Observable<std::vector<typeName>>::size) \
-		.function("at", &Observable<std::vector<typeName>>::at) \
-		.function("insert", &Observable<std::vector<typeName>>::insert) \
-		.function("set", &Observable<std::vector<typeName>>::set) \
-		.function("erase", &Observable<std::vector<typeName>>::erase) \
-		.function("subscribe", select_overload<std::shared_ptr<ISubscribeHandle>(ISubscribeHandleVectorCallback<typeName>*)>(&Observable<std::vector<typeName>>::subscribe), allow_raw_pointers()) \
+	class_<threadily::Observable<std::vector<typeName>>>(EXPAND_AND_QUOTE(ObservableVector##externalNameExtension)) \
+		.smart_ptr<std::shared_ptr<threadily::Observable<std::vector<typeName>>>>(EXPAND_AND_QUOTE(ObservableVector##externalNameExtension)) \
+		.function("size", &threadily::Observable<std::vector<typeName>>::size) \
+		.function("at", &threadily::Observable<std::vector<typeName>>::at) \
+		.function("insert", &threadily::Observable<std::vector<typeName>>::insert) \
+		.function("set", &threadily::Observable<std::vector<typeName>>::set) \
+		.function("erase", &threadily::Observable<std::vector<typeName>>::erase) \
+		.function("subscribe", select_overload<std::shared_ptr<threadily::ISubscribeHandle>(threadily::ISubscribeHandleVectorCallback<typeName>*)>(&threadily::Observable<std::vector<typeName>>::subscribe), allow_raw_pointers()) \
 		; \
-	class_<ISubscribeHandleVectorCallback<typeName>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##VectorCallback)) \
-		.smart_ptr<std::shared_ptr<ISubscribeHandleVectorCallback<typeName>>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##VectorCallback)) \
-		.function("onChange", &ISubscribeHandleVectorCallback<typeName>::onChange, pure_virtual()) \
+	class_<threadily::ISubscribeHandleVectorCallback<typeName>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##VectorCallback)) \
+		.smart_ptr<std::shared_ptr<threadily::ISubscribeHandleVectorCallback<typeName>>>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##VectorCallback)) \
+		.function("onChange", &threadily::ISubscribeHandleVectorCallback<typeName>::onChange, pure_virtual()) \
 		.allow_subclass<ISubscribeHandle##externalNameExtension##VectorCallbackWrapper>(EXPAND_AND_QUOTE(ISubscribeHandle##externalNameExtension##VectorCallbackWrapper)) \
 		; \
 

--- a/Threadily/ThreadObjectManager.h
+++ b/Threadily/ThreadObjectManager.h
@@ -104,7 +104,7 @@ namespace threadily {
 #if !defined(EMSCRIPTEN) || defined(USE_PTHREADS)
 			std::lock_guard<std::mutex> lock(instances_m);
 #endif
-			return this->getObject(threadId, object->getId());
+			return this->getOrOptionallyCreateObject(threadId, object->getId(), true);
 		}
 
 		std::shared_ptr<T> getObject(unsigned int threadId, int id)

--- a/Threadily/Threadily.vcxproj
+++ b/Threadily/Threadily.vcxproj
@@ -77,26 +77,42 @@
     </ClCompile>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cd
-xcopy /Y *.h $(OutputPath).
-IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 Observable.cpp ReadyEvent.cpp ThreadManager.cpp ThreadObject.cpp ThreadObjectManager.cpp ThreadQueueItem.cpp ThreadQueueItemHandler.cpp ThreadQueueItemManager.cpp -o $(OutputPath)$(TargetName).bc -Oz
+xcopy /s/Y *.h $(OutputPath).
+set LIST=
+SETLOCAL EnableDelayedExpansion 
+for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
+IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -o $(OutputPath)$(TargetName).bc -Oz
+ENDLOCAL
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cd
-xcopy /Y *.h $(OutputPath).
-IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 Observable.cpp ReadyEvent.cpp ThreadManager.cpp ThreadObject.cpp ThreadObjectManager.cpp ThreadQueueItem.cpp ThreadQueueItemHandler.cpp ThreadQueueItemManager.cpp -o $(OutputPath)$(TargetName).bc -Oz
+xcopy /s/Y *.h $(OutputPath).
+set LIST=
+SETLOCAL EnableDelayedExpansion 
+for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
+IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -o $(OutputPath)$(TargetName).bc -Oz
+ENDLOCAL
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cd
-xcopy /Y *.h $(OutputPath).
-IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 Observable.cpp ReadyEvent.cpp ThreadManager.cpp ThreadObject.cpp ThreadObjectManager.cpp ThreadQueueItem.cpp ThreadQueueItemHandler.cpp ThreadQueueItemManager.cpp -o $(OutputPath)$(TargetName).bc -Oz
+xcopy /s/Y *.h $(OutputPath).
+set LIST=
+SETLOCAL EnableDelayedExpansion 
+for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
+IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -o $(OutputPath)$(TargetName).bc -Oz
+ENDLOCAL
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cd
-xcopy /Y *.h $(OutputPath).
-IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 Observable.cpp ReadyEvent.cpp ThreadManager.cpp ThreadObject.cpp ThreadObjectManager.cpp ThreadQueueItem.cpp ThreadQueueItemHandler.cpp ThreadQueueItemManager.cpp -o $(OutputPath)$(TargetName).bc -Oz
+xcopy /s/Y *.h $(OutputPath).
+set LIST=
+SETLOCAL EnableDelayedExpansion 
+for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
+IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -o $(OutputPath)$(TargetName).bc -Oz
+ENDLOCAL
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
- Made #define for Observables global by including namespaces …  
- Simplified the emcc build so when we add new .cpp files they are included automatically
- Fixed bug in ThreadObjectManager::getPeer