### PR TITLE
Added example for how to clone subscribe responses for async use

### DIFF
--- a/Threadily.SampleObjects/Threadily.SampleObjects.vcxproj
+++ b/Threadily.SampleObjects/Threadily.SampleObjects.vcxproj
@@ -85,8 +85,8 @@ set LIST=
 SETLOCAL EnableDelayedExpansion 
 for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
 ECHO Building emscripten... this may take a bit
-REM "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -O0 -s NO_EXIT_RUNTIME=1 -s EXCEPTION_DEBUG=1
-"C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz -s NO_EXIT_RUNTIME=1
+REM emcc -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -O0 -s NO_EXIT_RUNTIME=1 -s EXCEPTION_DEBUG=1
+emcc -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz -s NO_EXIT_RUNTIME=1
 ENDLOCAL
 </Command>
     </PostBuildEvent>
@@ -96,8 +96,9 @@ xcopy /s/Y *.h $(OutputPath).
 set LIST=
 SETLOCAL EnableDelayedExpansion 
 for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
-REM IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -O0 -s NO_EXIT_RUNTIME=1 -s EXCEPTION_DEBUG=1
-IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz -s NO_EXIT_RUNTIME=1
+ECHO Building emscripten... this may take a bit
+REM emcc -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -O0 -s NO_EXIT_RUNTIME=1 -s EXCEPTION_DEBUG=1
+emcc -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz -s NO_EXIT_RUNTIME=1
 ENDLOCAL
 </Command>
     </PostBuildEvent>
@@ -107,8 +108,9 @@ xcopy /s/Y *.h $(OutputPath).
 set LIST=
 SETLOCAL EnableDelayedExpansion 
 for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
-REM IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -O0 -s NO_EXIT_RUNTIME=1 -s EXCEPTION_DEBUG=1
-IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz -s NO_EXIT_RUNTIME=1
+ECHO Building emscripten... this may take a bit
+REM emcc -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -O0 -s NO_EXIT_RUNTIME=1 -s EXCEPTION_DEBUG=1
+emcc -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz -s NO_EXIT_RUNTIME=1
 ENDLOCAL
 </Command>
     </PostBuildEvent>
@@ -118,8 +120,9 @@ xcopy /s/Y *.h $(OutputPath).
 set LIST=
 SETLOCAL EnableDelayedExpansion 
 for /f %%i in ('dir /b /a /s *.cpp') do set LIST=!LIST! %%i
-REM IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -O0 -s NO_EXIT_RUNTIME=1 -s EXCEPTION_DEBUG=1
-IF EXIST "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz -s NO_EXIT_RUNTIME=1
+ECHO Building emscripten... this may take a bit
+REM emcc -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -O0 -s NO_EXIT_RUNTIME=1 -s EXCEPTION_DEBUG=1
+emcc -std=c++11 %LIST% -I "$(OutputPath)..\Threadily" -o $(OutputPath)$(TargetName).bc -Oz -s NO_EXIT_RUNTIME=1
 ENDLOCAL
 </Command>
     </PostBuildEvent>

--- a/Threadily.test.web/Threadily.test.web.njsproj
+++ b/Threadily.test.web/Threadily.test.web.njsproj
@@ -74,8 +74,8 @@
       cd
       echo Building Threadily.SampleObjects.js into this directory
       del Threadily.SampleObjects.js*
-      REM "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 --bind ..\$(Configuration)\Threadily\Threadily.bc ..\$(Configuration)\Threadily.SampleObjects\Threadily.SampleObjects.bc -o Threadily.SampleObjects.js -O0 -s NO_EXIT_RUNTIME=1 -s EXCEPTION_DEBUG=1
-      "C:\Program Files\Emscripten\emscripten\1.35.0\emcc" -std=c++11 --bind ..\$(Configuration)\Threadily\Threadily.bc ..\$(Configuration)\Threadily.SampleObjects\Threadily.SampleObjects.bc -o Threadily.SampleObjects.js -Oz -s NO_EXIT_RUNTIME=1
+      REM emcc -std=c++11 --bind ..\$(Configuration)\Threadily\Threadily.bc ..\$(Configuration)\Threadily.SampleObjects\Threadily.SampleObjects.bc -o Threadily.SampleObjects.js -O0 -s NO_EXIT_RUNTIME=1 -s EXCEPTION_DEBUG=1
+      emcc -std=c++11 --bind ..\$(Configuration)\Threadily\Threadily.bc ..\$(Configuration)\Threadily.SampleObjects\Threadily.SampleObjects.bc -o Threadily.SampleObjects.js -Oz -s NO_EXIT_RUNTIME=1
     </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Have been running into an issue where the underlying pointer would be deleted when we stored the value coming from a subscriber for async usage. Added example in the tests for how to clone the values from the subscriber callbacks so that you can use them out of scope.

Also fixed the build for test code.